### PR TITLE
fix(ui): improve organization filter dropdown text styling

### DIFF
--- a/styles/components/OrgSwitcher.css
+++ b/styles/components/OrgSwitcher.css
@@ -102,6 +102,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  color: #fff;
 }
 
 .org-option:hover {
@@ -122,6 +123,8 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-weight: 500;
+  color: #fff;
 }
 
 .org-project-count {


### PR DESCRIPTION
## Summary

- Fix organization filter dropdown text styling for better readability
- Add explicit `color: #fff` to `.org-option` class
- Add `font-weight: 500` and `color: #fff` to `.org-option-name` class

This brings the OrgSwitcher dropdown styling in line with the ProjectSelector dropdown for visual consistency.

Fixes #114

## Test plan

- [x] Visual inspection of dropdown in browser
- [x] Lint check passes
- [x] Build succeeds
- [x] E2E tests pass (pre-push hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)