### PR TITLE
feat: SSG route for /organizations/[orgSlug]/issues/new

### DIFF
--- a/.centy/issues/72191b0f-0ca7-419d-8697-455acb435adc.md
+++ b/.centy/issues/72191b0f-0ca7-419d-8697-455acb435adc.md
@@ -1,10 +1,10 @@
 ---
 # This file is managed by Centy. Use the Centy CLI to modify it.
 displayNumber: 266
-status: open
+status: closed
 priority: 2
 createdAt: 2026-04-04T12:24:36.374368+00:00
-updatedAt: 2026-04-04T12:24:36.374368+00:00
+updatedAt: 2026-04-04T13:03:10.049950+00:00
 ---
 
 # SSG route: /organizations/[orgSlug]/issues/new

--- a/app/organizations/[orgSlug]/issues/new/page.tsx
+++ b/app/organizations/[orgSlug]/issues/new/page.tsx
@@ -7,11 +7,6 @@ export async function generateStaticParams() {
   return [{ orgSlug: '_placeholder' }]
 }
 
-export default async function NewOrgIssuePage({
-  params,
-}: {
-  params: Promise<{ orgSlug: string }>
-}) {
-  const { orgSlug } = await params
-  return <CreateOrgIssue orgSlug={orgSlug} />
+export default function NewOrgIssuePage() {
+  return <CreateOrgIssue />
 }

--- a/components/organizations/CreateOrgIssue/CreateOrgIssue.tsx
+++ b/components/organizations/CreateOrgIssue/CreateOrgIssue.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import Link from 'next/link'
+import { useParams } from 'next/navigation'
 import { route } from 'nextjs-routes'
-import type { CreateOrgIssueProps } from './CreateOrgIssue.types'
 import { useCreateOrgIssue } from './hooks/useCreateOrgIssue'
 import { CreateOrgIssueForm } from './CreateOrgIssueForm'
 
-export function CreateOrgIssue({ orgSlug }: CreateOrgIssueProps) {
+export function CreateOrgIssue() {
+  const orgSlug = String(useParams()?.orgSlug ?? '')
   const {
     orgProjectPath,
     initLoading,
@@ -23,7 +24,7 @@ export function CreateOrgIssue({ orgSlug }: CreateOrgIssueProps) {
     stateOptions,
     handleSubmit,
     handleCancel,
-  } = useCreateOrgIssue(orgSlug)
+  } = useCreateOrgIssue()
 
   return (
     <div className="create-issue">
@@ -59,7 +60,6 @@ export function CreateOrgIssue({ orgSlug }: CreateOrgIssueProps) {
         </div>
       ) : (
         <CreateOrgIssueForm
-          orgSlug={orgSlug}
           title={title}
           setTitle={setTitle}
           description={description}

--- a/components/organizations/CreateOrgIssue/CreateOrgIssue.types.ts
+++ b/components/organizations/CreateOrgIssue/CreateOrgIssue.types.ts
@@ -1,3 +1,1 @@
-export interface CreateOrgIssueProps {
-  orgSlug: string
-}
+export type CreateOrgIssueProps = Record<string, never>

--- a/components/organizations/CreateOrgIssue/CreateOrgIssueForm.types.ts
+++ b/components/organizations/CreateOrgIssue/CreateOrgIssueForm.types.ts
@@ -1,5 +1,4 @@
 export interface CreateOrgIssueFormProps {
-  orgSlug: string
   title: string
   setTitle: (v: string) => void
   description: string

--- a/components/organizations/CreateOrgIssue/hooks/useCreateOrgIssue.ts
+++ b/components/organizations/CreateOrgIssue/hooks/useCreateOrgIssue.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useParams } from 'next/navigation'
 import { route } from 'nextjs-routes'
 import { create } from '@bufbuild/protobuf'
 import { useOrgProjectPath } from './useOrgProjectPath'
@@ -11,7 +11,10 @@ function formatSubmitErr(err: unknown): string {
   return err instanceof Error ? err.message : 'Failed to connect to daemon'
 }
 
-export function useCreateOrgIssue(orgSlug: string) {
+export function useCreateOrgIssue() {
+  const params = useParams()
+  const orgSlugParam = params ? params.orgSlug : undefined
+  const orgSlug = typeof orgSlugParam === 'string' ? orgSlugParam : ''
   const router = useRouter()
   const stateManager = useStateManager()
   const stateOptions = stateManager.getStateOptions()


### PR DESCRIPTION
## Summary
- Read `orgSlug` from `useParams()` inside `CreateOrgIssue` and `useCreateOrgIssue` instead of passing it as a prop from the server component
- Page is now a plain function (no async params) compatible with static generation
- Removed unused `orgSlug` from `CreateOrgIssueFormProps`

## Test plan
- [ ] TypeScript compiles without errors in changed files
- [ ] Unit tests pass for `useCreateOrgIssue` and `useOrgProjectPath`
- [ ] Build produces SSG output for `/organizations/[orgSlug]/issues/new`

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)