### PR TITLE
chore: close issue #260 - SSG route for /[organization]/[project]/users

### DIFF
--- a/.centy/issues/84813dd2-0192-4e6b-8a07-1cdb0b27a82a.md
+++ b/.centy/issues/84813dd2-0192-4e6b-8a07-1cdb0b27a82a.md
@@ -1,10 +1,10 @@
 ---
 # This file is managed by Centy. Use the Centy CLI to modify it.
 displayNumber: 260
-status: open
+status: closed
 priority: 2
 createdAt: 2026-04-04T12:24:31.086990+00:00
-updatedAt: 2026-04-04T12:24:31.086990+00:00
+updatedAt: 2026-04-04T16:14:23.540935+00:00
 ---
 
 # SSG route: /[organization]/[project]/users


### PR DESCRIPTION
## Summary
- SSG route `/[organization]/[project]/users` was already implemented in PR #183
- Verified build correctly generates `/_placeholder/_placeholder/users` as an SSG (`●`) route
- Closed centy issue #260 and updated submodule to latest

## Test plan
- [x] `npm run build` succeeds with `/[organization]/[project]/users` listed as SSG route

🤖 Generated with [Claude Code](https://claude.com/claude-code)