### PR TITLE
feat: show linkage section in all item type detail views

### DIFF
--- a/.centy/issues/2399d871-08f9-45d8-bb5a-b8cac5044ad9.md
+++ b/.centy/issues/2399d871-08f9-45d8-bb5a-b8cac5044ad9.md
@@ -1,0 +1,60 @@
+---
+# This file is managed by Centy. Use the Centy CLI to modify it.
+displayNumber: 271
+status: closed
+priority: 2
+createdAt: 2026-04-13T17:09:59.897678+00:00
+updatedAt: 2026-04-13T17:21:40.786270+00:00
+---
+
+# Show linkage section in all item type detail views
+
+## Problem
+
+Linkage (the "Relations" / Links section) is only surfaced in the **Issue** detail view via `IssueSidebar.tsx`. All other item types — Docs, Stories, Personas, and Org Issues — have no links UI despite the backend fully supporting cross-type links.
+
+This creates an asymmetry: users can create a link _from_ an issue to a doc or story, but opening that doc or story shows no links at all, making the relationship invisible from the other side.
+
+## Current state
+
+| Item type | LinkSection shown? | Component                               |
+| --------- | ------------------ | --------------------------------------- |
+| Issue     | ✅ Yes             | `IssueSidebar.tsx` → `LinkSection`      |
+| Doc       | ❌ No              | `GenericItemView.tsx` (no LinkSection)  |
+| Story     | ❌ No              | `GenericItemView.tsx` (no LinkSection)  |
+| Persona   | ❌ No              | `GenericItemView.tsx` (no LinkSection)  |
+| Org Issue | ❌ No              | `OrgIssueReadView.tsx` (no LinkSection) |
+
+## Root cause
+
+1. **Type constraint is too narrow.** `LinkSectionProps.entityType` and the `useLinkSection` hook signature are typed as `'issue' | 'doc'` instead of accepting all item types.
+2. **`GenericItemView` sidebar lacks LinkSection.** Docs, Stories, and Personas all render through `GenericItemView.tsx` → `DetailLayout`, but no `LinkSection` is mounted in that sidebar.
+3. **`OrgIssueReadView` has no LinkSection** in its `DetailLayout` sidebar slot.
+
+## What needs to change
+
+### 1. Broaden the `entityType` type constraint
+
+- `components/shared/LinkSection/LinkSectionProps.ts` — widen `entityType` from `'issue' | 'doc'` to `string` (or a union of all supported types)
+- `components/shared/LinkSection/useLinkSection.ts` — update function signature to match
+
+### 2. Add LinkSection to `GenericItemView`
+
+- `components/generic/GenericItemView.tsx` — mount `<LinkSection>` in the sidebar, passing the item's type slug and id, conditioned on `editable` where appropriate
+
+### 3. Add LinkSection to `OrgIssueReadView`
+
+- `components/organizations/OrgIssueDetail/OrgIssueReadView.tsx` — mount `<LinkSection>` in the sidebar
+
+### 4. Verify routing and fetch hooks handle all item types
+
+- `components/shared/LinkSection/useLinkRoutes.ts` — confirm item-type-to-route mapping covers docs, stories, personas
+- `components/shared/LinkSection/useLinkFetch.ts` — confirm fetch logic is not issue-specific
+
+## Acceptance criteria
+
+- Opening a Doc, Story, or Persona that has at least one incoming or outgoing link shows those links in a Relations/Links section in the detail sidebar
+- Opening an Org Issue with links shows those links in its sidebar
+- The AddLinkModal works correctly when opened from any item type (search returns items of all types, icons render correctly)
+- No regression in Issue linkage behaviour
+- `entityType` type constraint is no longer artificially restricted to `'issue' | 'doc'`

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,4 +5,4 @@ coverage
 pnpm-lock.yaml
 next-env.d.ts
 gen/
-.centy/.centy-manifest.json
+.centy/

--- a/@types/nextjs-routes.d.ts
+++ b/@types/nextjs-routes.d.ts
@@ -25,6 +25,9 @@ declare module "nextjs-routes" {
     | DynamicRoute<"/[organization]/[project]/users", { "organization": string; "project": string }>
     | DynamicRoute<"/[organization]/[project]/users/[userId]", { "organization": string; "project": string; "userId": string }>
     | DynamicRoute<"/[organization]/[project]/users/new", { "organization": string; "project": string }>
+    | DynamicRoute<"/[organization]/[project]/[itemType]", { "organization": string; "project": string; "itemType": string }>
+    | DynamicRoute<"/[organization]/[project]/[itemType]/[slug]", { "organization": string; "project": string; "itemType": string; "slug": string }>
+    | DynamicRoute<"/[organization]/[project]/[itemType]/new", { "organization": string; "project": string; "itemType": string }>
     | StaticRoute<"/archived">
     | StaticRoute<"/assets">
     | StaticRoute<"/daemon">

--- a/components/generic/DetailBody.tsx
+++ b/components/generic/DetailBody.tsx
@@ -7,6 +7,7 @@ interface DetailBodyProps {
   item: GenericItem
   config: ItemTypeConfigProto | null
   isEditing: boolean
+  itemType: string
   projectPath: string
   fetch: ReturnType<typeof useGenericItemFetch>
 }
@@ -15,6 +16,7 @@ export function DetailBody({
   item,
   config,
   isEditing,
+  itemType,
   projectPath,
   fetch,
 }: DetailBodyProps): React.JSX.Element {
@@ -37,5 +39,5 @@ export function DetailBody({
       />
     )
   }
-  return <GenericItemView item={item} config={config} />
+  return <GenericItemView item={item} config={config} itemType={itemType} />
 }

--- a/components/generic/GenericItemContent.tsx
+++ b/components/generic/GenericItemContent.tsx
@@ -63,6 +63,7 @@ export function GenericItemContent({
           item={item}
           config={state.config}
           isEditing={state.isEditing}
+          itemType={itemType}
           projectPath={projectPath}
           fetch={state.fetch}
         />

--- a/components/generic/GenericItemView.tsx
+++ b/components/generic/GenericItemView.tsx
@@ -3,13 +3,19 @@ import { TextEditor } from '@/components/shared/TextEditor'
 import { ItemMetadata } from '@/components/shared/ItemMetadata'
 import { ItemTitle } from '@/components/shared/ItemView'
 import { DetailLayout } from '@/components/shared/DetailLayout/DetailLayout'
+import { LinkSection } from '@/components/shared/LinkSection'
 
 interface GenericItemViewProps {
   item: GenericItem
   config: ItemTypeConfigProto | null
+  itemType: string
 }
 
-export function GenericItemView({ item, config }: GenericItemViewProps) {
+export function GenericItemView({
+  item,
+  config,
+  itemType,
+}: GenericItemViewProps) {
   const meta = item.metadata
   const customFields = meta ? meta.customFields : {}
   const showStatus = Boolean(
@@ -30,21 +36,31 @@ export function GenericItemView({ item, config }: GenericItemViewProps) {
         </div>
       }
       sidebar={
-        <div className="sidebar-section">
-          <h3 className="sidebar-section-title">Properties</h3>
-          <ItemMetadata
-            status={showStatus && meta ? meta.status : undefined}
-            customFields={customFields}
-            customFieldsConfig={config ? config.customFields : undefined}
-            projects={meta ? meta.projects : undefined}
-            createdAt={meta ? meta.createdAt : undefined}
-            updatedAt={meta ? meta.updatedAt : undefined}
-          >
-            <span className="generic-item-id-display">
-              <span className="field-label">ID:</span> {item.id}
-            </span>
-          </ItemMetadata>
-        </div>
+        <>
+          <div className="sidebar-section">
+            <h3 className="sidebar-section-title">Properties</h3>
+            <ItemMetadata
+              status={showStatus && meta ? meta.status : undefined}
+              customFields={customFields}
+              customFieldsConfig={config ? config.customFields : undefined}
+              projects={meta ? meta.projects : undefined}
+              createdAt={meta ? meta.createdAt : undefined}
+              updatedAt={meta ? meta.updatedAt : undefined}
+            >
+              <span className="generic-item-id-display">
+                <span className="field-label">ID:</span> {item.id}
+              </span>
+            </ItemMetadata>
+          </div>
+          <div className="sidebar-section">
+            <h3 className="sidebar-section-title">Relations</h3>
+            <LinkSection
+              entityId={item.id}
+              entityType={itemType}
+              editable={true}
+            />
+          </div>
+        </>
       }
     />
   )

--- a/components/organizations/OrgIssueDetail/OrgIssueReadView.tsx
+++ b/components/organizations/OrgIssueDetail/OrgIssueReadView.tsx
@@ -5,6 +5,7 @@ import { TextEditor } from '@/components/shared/TextEditor'
 import { ItemMetadata } from '@/components/shared/ItemMetadata'
 import { ItemTitle } from '@/components/shared/ItemView'
 import { DetailLayout } from '@/components/shared/DetailLayout/DetailLayout'
+import { LinkSection } from '@/components/shared/LinkSection'
 
 interface OrgIssueReadViewProps {
   issue: GenericItem
@@ -35,17 +36,27 @@ export function OrgIssueReadView({ issue }: OrgIssueReadViewProps) {
         </>
       }
       sidebar={
-        <div className="sidebar-section">
-          <h3 className="sidebar-section-title">Properties</h3>
-          <ItemMetadata
-            status={status}
-            priority={priority}
-            createdAt={meta ? meta.createdAt : undefined}
-            updatedAt={meta ? meta.updatedAt : undefined}
-          >
-            <span className="org-issue-badge">Org Issue #{displayNum}</span>
-          </ItemMetadata>
-        </div>
+        <>
+          <div className="sidebar-section">
+            <h3 className="sidebar-section-title">Properties</h3>
+            <ItemMetadata
+              status={status}
+              priority={priority}
+              createdAt={meta ? meta.createdAt : undefined}
+              updatedAt={meta ? meta.updatedAt : undefined}
+            >
+              <span className="org-issue-badge">Org Issue #{displayNum}</span>
+            </ItemMetadata>
+          </div>
+          <div className="sidebar-section">
+            <h3 className="sidebar-section-title">Relations</h3>
+            <LinkSection
+              entityId={issue.id}
+              entityType="org_issue"
+              editable={true}
+            />
+          </div>
+        </>
       }
     />
   )

--- a/components/shared/AddLinkModal/AddLinkModalProps.ts
+++ b/components/shared/AddLinkModal/AddLinkModalProps.ts
@@ -2,7 +2,7 @@ import type { Link as LinkType } from '@/gen/centy_pb'
 
 export interface AddLinkModalProps {
   entityId: string
-  entityType: 'issue' | 'doc'
+  entityType: string
   existingLinks: LinkType[]
   onClose: () => void
   onLinkCreated: () => void

--- a/components/shared/AddLinkModal/LinkPreview.tsx
+++ b/components/shared/AddLinkModal/LinkPreview.tsx
@@ -3,7 +3,7 @@
 import type { EntityItem } from './AddLinkModal.types'
 
 interface LinkPreviewProps {
-  entityType: 'issue' | 'doc'
+  entityType: string
   selectedLinkType: string
   selectedTarget: EntityItem
   getInverseLinkType: (linkType: string) => string

--- a/components/shared/AddLinkModal/useCreateLink.ts
+++ b/components/shared/AddLinkModal/useCreateLink.ts
@@ -7,7 +7,7 @@ import { CreateLinkRequestSchema } from '@/gen/centy_pb'
 export function useCreateLink(
   projectPath: string,
   entityId: string,
-  entityType: 'issue' | 'doc',
+  entityType: string,
   selectedTarget: EntityItem | null,
   selectedLinkType: string,
   onLinkCreated: () => void

--- a/components/shared/LinkSection/LinkSectionModals.tsx
+++ b/components/shared/LinkSection/LinkSectionModals.tsx
@@ -6,7 +6,7 @@ import type { useLinkSection } from './useLinkSection'
 interface LinkSectionModalsProps {
   state: ReturnType<typeof useLinkSection>
   entityId: string
-  entityType: 'issue' | 'doc'
+  entityType: string
 }
 
 export function LinkSectionModals({

--- a/components/shared/LinkSection/LinkSectionProps.ts
+++ b/components/shared/LinkSection/LinkSectionProps.ts
@@ -1,6 +1,6 @@
 export interface LinkSectionProps {
   entityId: string
-  entityType: 'issue' | 'doc'
+  entityType: string
   /** Whether the user can add/remove links (edit mode) */
   editable?: boolean
 }

--- a/components/shared/LinkSection/useLinkFetch.ts
+++ b/components/shared/LinkSection/useLinkFetch.ts
@@ -33,7 +33,7 @@ async function fetchLinkTitles(
   return Object.fromEntries(entries)
 }
 
-export function useLinkFetch(entityId: string, entityType: 'issue' | 'doc') {
+export function useLinkFetch(entityId: string, entityType: string) {
   const { projectPath } = usePathContext()
   const [links, setLinks] = useState<LinkType[]>([])
   const [linkTitles, setLinkTitles] = useState<Record<string, string>>({})

--- a/components/shared/LinkSection/useLinkRoutes.ts
+++ b/components/shared/LinkSection/useLinkRoutes.ts
@@ -31,7 +31,10 @@ export function useLinkRoutes(): {
           query: { ...projectContext, slug: targetId },
         })
       }
-      return route({ pathname: '/' })
+      return route({
+        pathname: '/[organization]/[project]/[itemType]/[slug]',
+        query: { ...projectContext, itemType: targetItemType, slug: targetId },
+      })
     },
     [projectContext]
   )

--- a/components/shared/LinkSection/useLinkSection.ts
+++ b/components/shared/LinkSection/useLinkSection.ts
@@ -3,7 +3,7 @@ import { useLinkFetch } from './useLinkFetch'
 import { useLinkRoutes } from './useLinkRoutes'
 import type { Link as LinkType } from '@/gen/centy_pb'
 
-export function useLinkSection(entityId: string, entityType: 'issue' | 'doc') {
+export function useLinkSection(entityId: string, entityType: string) {
   const { buildLinkRoute } = useLinkRoutes()
   const {
     links,

--- a/cspell.json
+++ b/cspell.json
@@ -104,6 +104,7 @@
     "coverage",
     "pnpm-lock.yaml",
     "*.min.js",
-    "gen/**"
+    "gen/**",
+    ".centy/**"
   ]
 }


### PR DESCRIPTION
## Summary

- Widened `entityType` from `'issue' | 'doc'` to `string` throughout `LinkSection`, `LinkSectionModals`, and `AddLinkModal` components
- Added a **Relations/Links sidebar section** to `GenericItemView` (covers Docs, Stories, Personas, and any future generic item types)
- Added a **Relations/Links sidebar section** to `OrgIssueReadView`
- Extended `useLinkRoutes` to handle generic item types via the `/[organization]/[project]/[itemType]/[slug]` route as a fallback
- Registered the missing `/[organization]/[project]/[itemType]` dynamic routes in `nextjs-routes.d.ts`
- Excluded `.centy/` from prettier and cspell (managed content, not project code)

Closes #271

## Test plan

- [ ] Open a Doc/Story/Persona that has an incoming link from an issue — verify Relations section appears in the sidebar
- [ ] Verify "Add Link" button opens the modal and creating a link works from a generic item type
- [ ] Verify existing Issue linkage behaviour is unchanged
- [ ] `pnpm tsc --noEmit` — no new errors
- [ ] `pnpm test` — all 561 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)