### PR TITLE
feat(lint): enable @typescript-eslint/prefer-readonly

### DIFF
--- a/e2e/utils/mock-grpc.ts
+++ b/e2e/utils/mock-grpc.ts
@@ -8,9 +8,9 @@ import { createRouteHandler } from './mock-grpc-route-handler'
  * Intercepts HTTP requests to the daemon URL and returns mock responses.
  */
 export class GrpcMocker {
-  private page: Page
-  private handlers: Map<string, HandlerConfig>
-  private daemonUrl: string
+  private readonly page: Page
+  private readonly handlers: Map<string, HandlerConfig>
+  private readonly daemonUrl: string
   private isSetup: boolean
 
   constructor(page: Page, daemonUrl?: string) {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -39,6 +39,9 @@ export default [
         'error',
         { allowNumber: true },
       ],
+      // Flag private members assigned only in the constructor/at declaration
+      // and never reassigned, so immutability intent is explicit and enforced.
+      '@typescript-eslint/prefer-readonly': 'error',
     },
   },
   {

--- a/lib/state/StateManagerClass.ts
+++ b/lib/state/StateManagerClass.ts
@@ -10,8 +10,8 @@ export class StateManager {
   private static DEFAULT_COLORS: Record<string, string>
   private static DEFAULT_STATE: string
 
-  private config: Config | null
-  private itemTypeStatuses: string[]
+  private readonly config: Config | null
+  private readonly itemTypeStatuses: string[]
 
   static {
     StateManager.DEFAULT_STATES = ['open', 'in-progress', 'closed'] as const


### PR DESCRIPTION
## What

Enables the [`@typescript-eslint/prefer-readonly`](https://typescript-eslint.io/rules/prefer-readonly/) ESLint rule (as `error`) in `eslint.config.js`, and applies the 5 `readonly` fixes it flags.

## Changes

- `eslint.config.js` — add `'@typescript-eslint/prefer-readonly': 'error'` to the typed-files rule block.
- `e2e/utils/mock-grpc.ts` — `page`, `handlers`, `daemonUrl` → `readonly` (assigned only in the constructor).
- `lib/state/StateManagerClass.ts` — `config`, `itemTypeStatuses` → `readonly` (assigned only in the constructor).

`isSetup` in `mock-grpc.ts` is intentionally left mutable (reassigned in setup/teardown).

## Why

Makes immutability intent explicit and lets the type-checker turn any future accidental reassignment into a compile-time error.

## Checks

`pnpm lint` passes locally — 0 errors (pre-existing warnings unchanged).

Closes #215

---
This pull request was opened by the "Open issues → fix PRs (owned repos + my orgs)" routine of moadim.