### PR TITLE
chore: add missing changesets

### DIFF
--- a/.changeset/add-link-modal-search.md
+++ b/.changeset/add-link-modal-search.md
@@ -1,0 +1,5 @@
+---
+"centy-app": patch
+---
+
+Unify the Add Link modal's search into a single combobox with type icons, replacing the separate search/results fields. (#195, #202)

--- a/.changeset/edit-link-functionality.md
+++ b/.changeset/edit-link-functionality.md
@@ -1,0 +1,5 @@
+---
+"centy-app": minor
+---
+
+Add edit-link functionality, letting existing links between items be modified instead of only created or removed. (#194)

--- a/.changeset/linkage-section-detail-views.md
+++ b/.changeset/linkage-section-detail-views.md
@@ -1,0 +1,5 @@
+---
+"centy-app": minor
+---
+
+Show the linkage section (linked items) in every item type's detail view, not just a subset. (#210)

--- a/.changeset/mermaid-diagrams.md
+++ b/.changeset/mermaid-diagrams.md
@@ -1,0 +1,5 @@
+---
+"centy-app": minor
+---
+
+Render Mermaid diagrams inside item descriptions instead of showing the raw code block. (#208)

--- a/.changeset/multi-project-items.md
+++ b/.changeset/multi-project-items.md
@@ -1,0 +1,5 @@
+---
+"centy-app": minor
+---
+
+Support items that belong to multiple projects in the UI, instead of assuming each item has exactly one project. (#199)

--- a/.changeset/open-in-x-worktree-redirect.md
+++ b/.changeset/open-in-x-worktree-redirect.md
@@ -1,0 +1,5 @@
+---
+"centy-app": patch
+---
+
+Point the "Open in X" action at worktree.io. (#214)

--- a/.changeset/ssg-org-project-routes.md
+++ b/.changeset/ssg-org-project-routes.md
@@ -1,0 +1,5 @@
+---
+"centy-app": patch
+---
+
+Convert several organization/project/issue pages to statically-generated routes for faster loads. (#196, #197, #201, #205)


### PR DESCRIPTION
Adds pending changesets for merged, user-relevant work since the last release (v0.1.1, 2026-04-04) that predates the changesets bootstrap (#217) and never got one:

- **minor** — Edit-link functionality (#194)
- **minor** — Multi-project item support in the UI (#199)
- **patch** — Unified search combobox in the Add Link modal (#195, #202)
- **minor** — Mermaid diagram rendering in item descriptions (#208)
- **minor** — Linkage section shown in every item type's detail view (#210)
- **patch** — "Open in X" now redirects to worktree.io (#214)
- **patch** — Several org/project/issue pages converted to statically-generated routes (#196, #197, #201, #205)

Excluded as not user-relevant: internal issue-tracker bookkeeping commits ("close issue #NNN"), pure refactors (AddLinkModal/EditLinkModal unification), dev-tooling additions (PurgeCSS integration), and lint-rule chores.

Depends on the changesets bootstrap in #217 landing first (or independently — the `.md` files here don't require the config to exist).

---
This pull request was opened by the Changesets keeper (owned repos + my orgs) routine of moadim.