### PR TITLE
Adopt linecheck for per-file line-count limits

### DIFF
--- a/.github/workflows/linecheck.yml
+++ b/.github/workflows/linecheck.yml
@@ -1,0 +1,16 @@
+name: linecheck
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: tupe12334/linecheck@main
+        with:
+          paths: .

--- a/linecheck.yml
+++ b/linecheck.yml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/tupe12334/linecheck/main/schema/linecheck.schema.json
+
+rules:
+  - pattern: "**/*.{ts,tsx}"
+    warn: 200
+    warn_message: "Getting long — consider splitting into smaller modules/components"
+    error: 400
+    error_message: "Too large to review easily; split this file before merging"
+
+exclude:
+  - "gen/**"
+  - "node_modules/**"
+  - ".next/**"
+  - "pnpm-lock.yaml"
+  - "styles/**"
+  - "@types/nextjs-routes.d.ts"


### PR DESCRIPTION
Closes #220

Adds [linecheck](https://github.com/tupe12334/linecheck) to enforce per-file line-count limits.

- `linecheck.yml`: `**/*.{ts,tsx}` at warn 200 / error 400 (the `--default` preset), excluding `gen/**` (protobuf codegen), `node_modules/**`, `.next/**`, `pnpm-lock.yaml`, `styles/**`, and the generated `@types/nextjs-routes.d.ts`.
- `.github/workflows/linecheck.yml`: runs `tupe12334/linecheck@main` on push/PR to `main`.

Verified locally against current `main` (shallow clone + `linecheck .`): exit `0`, one non-blocking warn on `components/shared/TextEditor/TextEditor.css` (298 lines, caught by the tool's fallback default since it's outside the `ts/tsx` rule and `styles/`). No errors — this won't break CI on day one.

---
Opened automatically by the moadim routine **"Scout & wire linecheck adoption → Slack"**.