### PR TITLE
docs: fix validation findings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ pnpm test:watch
 
 - `pnpm dev` - Start development server
 - `pnpm build` - Build for production
-- `pnpm preview` - Preview production build
+- `pnpm start` - Serve the production build
 - `pnpm test` - Run tests
 - `pnpm test:coverage` - Run tests with coverage
 - `pnpm lint` - Check code quality

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Centy App
 
-A React application built with Vite and TypeScript, deployed as a Docker image to `centy-io/centy`.
+A React application built with Next.js and TypeScript, deployed to Cloudflare Pages.
 
 **[📚 Documentation](https://docs.centy.io)** | **[Report an Issue](https://github.com/centy-io/centy-app/issues)**
 
@@ -19,7 +19,7 @@ pnpm install
 # Start development server
 pnpm dev
 
-# Open http://localhost:5173 in your browser
+# Open http://localhost:5180 in your browser
 ```
 
 ## Available Scripts
@@ -28,7 +28,7 @@ pnpm dev
 | -------------------- | ------------------------------ |
 | `pnpm dev`           | Start development server       |
 | `pnpm build`         | Build for production           |
-| `pnpm preview`       | Preview production build       |
+| `pnpm start`         | Serve the production build     |
 | `pnpm test`          | Run tests                      |
 | `pnpm test:watch`    | Run tests in watch mode        |
 | `pnpm test:coverage` | Run tests with coverage report |
@@ -55,26 +55,25 @@ docker run -p 3000:80 centy-app
 
 This project uses GitHub Actions for CI/CD:
 
-- **On Pull Request**: Runs tests, linting, and build
-- **On Push to Main**: Runs tests, then builds and pushes Docker image to `centy-io/centy`
+- **On Pull Request**: Runs linting, tests, and build (`ci.yml`)
+- **On Push to Main**: After CI succeeds, builds and deploys the static export to Cloudflare Pages (`deploy.yml`)
 
 ### Required Secrets
 
-| Secret               | Description                     |
-| -------------------- | ------------------------------- |
-| `DOCKERHUB_USERNAME` | Docker Hub username             |
-| `DOCKERHUB_TOKEN`    | Docker Hub access token         |
-| `CODECOV_TOKEN`      | (Optional) Codecov upload token |
+| Secret                  | Description                     |
+| ----------------------- | ------------------------------- |
+| `CLOUDFLARE_API_TOKEN`  | Cloudflare Pages API token      |
+| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID           |
 
 ## Project Structure
 
 ```
-src/
-  App.tsx           # Main application component
-  App.spec.tsx      # Tests for App component
-  main.tsx          # Application entry point
-  test/
-    setup.ts        # Test setup (jest-dom matchers)
+app/          # Next.js App Router pages and layouts
+components/   # Shared React components
+hooks/        # Shared React hooks
+lib/          # Utilities and client logic
+proto/        # Protobuf definitions (pnpm proto regenerates gen/)
+e2e/          # Playwright end-to-end tests
 ```
 
 ## Contributing


### PR DESCRIPTION
- README.md:3 — described the app as "built with Vite … deployed as a Docker image to `centy-io/centy`"; it is a Next.js app deployed to Cloudflare Pages (`next.config.ts`, `.github/workflows/deploy.yml`).
- README.md:22 — dev-server URL said `http://localhost:5173` (Vite default); `pnpm dev` runs `next dev -p 5180`.
- README.md:31 / CONTRIBUTING.md — documented `pnpm preview`, which does not exist in `package.json`; replaced with `pnpm start` (serves the production build).
- README.md:54-67 — CI/CD section claimed a Docker Hub push with `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`/`CODECOV_TOKEN` secrets; actual pipeline deploys to Cloudflare Pages using `CLOUDFLARE_API_TOKEN`/`CLOUDFLARE_ACCOUNT_ID`.
- README.md:71-78 — Project Structure listed `src/App.tsx`, `src/main.tsx`, `src/test/setup.ts`; no `src/` directory exists — replaced with the actual `app/`, `components/`, `hooks/`, `lib/`, `proto/`, `e2e/` layout.

Not fixed (needs a source-code decision): the Docker sections in README/CONTRIBUTING say `docker run -p 3000:80 centy-app`, but the image has nothing listening on port 80 (Dockerfile EXPOSEs 3000, while its `CMD pnpm start` actually serves on 5180) — the Dockerfile/start script should be reconciled before documenting a port mapping.

🤖 This PR was opened automatically by the moadim routine "Weekly docs validation + fix PRs for repos I worked on".

🤖 Generated with [Claude Code](https://claude.com/claude-code)